### PR TITLE
Allow the user to set a custom folder for the disk cache.

### DIFF
--- a/lib/src/main/java/com/vincentbrison/openlibraries/android/dualcache/lib/DualCache.java
+++ b/lib/src/main/java/com/vincentbrison/openlibraries/android/dualcache/lib/DualCache.java
@@ -122,6 +122,12 @@ public class DualCache<T> {
      */
     private int mDiskCacheSizeInBytes;
 
+
+    /**
+     * Define the folder in which the disk cache will save its files.
+     */
+    private File mDiskCacheFolder;
+
     /**
      * Define the app version of the application (allow you to automatically invalidate data
      * from different app version on disk).
@@ -247,6 +253,14 @@ public class DualCache<T> {
 
     protected void setDiskCacheSizeInBytes(int diskCacheSizeInBytes) {
         mDiskCacheSizeInBytes = diskCacheSizeInBytes;
+    }
+
+    public File getDiskCacheFolder() {
+        return mDiskCacheFolder;
+    }
+
+    public void setDiskCacheFolder(File folder) {
+        mDiskCacheFolder = folder;
     }
 
     /**
@@ -477,8 +491,7 @@ public class DualCache<T> {
         if (!mDiskMode.equals(DualCacheDiskMode.DISABLE)) {
             try {
                 mDiskLruCache.delete();
-                File folder = new File(DualCacheContextUtils.getContext().getCacheDir().getPath() + "/" + CACHE_FILE_PREFIX + "/" + mId);
-                mDiskLruCache = DiskLruCache.open(folder, mAppVersion, 1, mDiskCacheSizeInBytes);
+                mDiskLruCache = DiskLruCache.open(mDiskCacheFolder, mAppVersion, 1, mDiskCacheSizeInBytes);
             } catch (IOException e) {
                 DualCacheLogUtils.logError(e);
             }


### PR DESCRIPTION
Hi Vincent,

I made this small change that would allow the user to define the disk cache folder. It doesn't break existing functionality, the previous **use...()** method signatures remain the same and they use `getDefaultDiskCacheFolder(usePrivateFiles)` to retrieve the previously defined default folders. What I did was add an overload of those methods allowing the user to define their own folder, and removed some code repetition by creating a single private function that takes care of the setup of the disk cache in `mDuaCache`.
I believe I have also fixed a bug in `DualCache.java`, where after an `invalidate()` call you were re-creating the disk cache using the `context.getCacheDir()` base folder, regardless if the user set it up with `usePrivateFiles` or not.
The motivation for me to do this is that in the app I'm currently working I need to store my cache in the external cache dir (SD card), rather than the internal one.

If you think this is a good addition, please merge this pull request.
Thanks for the library, it's great.
Rafael.