### PR TITLE
adding NPE in catch block

### DIFF
--- a/dualcache-library/src/main/java/com/vincentbrison/openlibraries/android/dualcache/DualCache.java
+++ b/dualcache-library/src/main/java/com/vincentbrison/openlibraries/android/dualcache/DualCache.java
@@ -165,7 +165,7 @@ public class DualCache<T> implements Closeable {
                     editor.set(0, diskSerializer.toString(object));
                 }
                 editor.commit();
-            } catch (IOException e) {
+            } catch (IOException | NullPointerException e) {
                 logger.logError(e);
             } finally {
                 dualCacheLock.unLockDiskEntryWrite(key);


### PR DESCRIPTION
Attempt to invoke virtual method 'void com.jakewharton.a.a$a.a(int, java.lang.String)' on a null object reference
com.vincentbrison.openlibraries.android.dualcache.DualCache.put (SourceFile:276)(version 3.0.0)